### PR TITLE
Implement password reset functionality

### DIFF
--- a/back_port/settings.py
+++ b/back_port/settings.py
@@ -142,3 +142,7 @@ ROOT_URLCONF = 'back_port.urls'
 # WSGI Configuration
 # --------------------------------------
 WSGI_APPLICATION = 'back_port.wsgi.application'
+
+# Email settings
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+DEFAULT_FROM_EMAIL = 'webmaster@localhost'

--- a/base/serializers.py
+++ b/base/serializers.py
@@ -148,3 +148,12 @@ class ProjectSerializer(serializers.ModelSerializer):
     class Meta:
         model = Project
         fields = ['id', 'title', 'github_link', 'description', 'skills', 'images']
+
+# Password reset
+class PasswordResetSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+
+class PasswordResetConfirmSerializer(serializers.Serializer):
+    uid = serializers.CharField()
+    token = serializers.CharField()
+    new_password = serializers.CharField(write_only=True)

--- a/base/urls.py
+++ b/base/urls.py
@@ -1,5 +1,20 @@
 from django.urls import path
-from .views import CommentList, TechnicalSkillCategoryList, WorkExperienceList, ValidateTokenView, TechnicalSkillCategoryCreate, TechnicalSkillCreate, TechnicalSkillUpdate, TechnicalSkillCategoryUpdate, StudyList, ProjectList, MyTokenObtainPairView, UserRegistrationAPIView
+from .views import (
+    CommentList,
+    TechnicalSkillCategoryList,
+    WorkExperienceList,
+    ValidateTokenView,
+    TechnicalSkillCategoryCreate,
+    TechnicalSkillCreate,
+    TechnicalSkillUpdate,
+    TechnicalSkillCategoryUpdate,
+    StudyList,
+    ProjectList,
+    MyTokenObtainPairView,
+    UserRegistrationAPIView,
+    PasswordResetView,
+    PasswordResetConfirmView,
+)
 from rest_framework_simplejwt.views import TokenRefreshView
 
 
@@ -16,7 +31,10 @@ urlpatterns = [
 
 	path('comments/', CommentList.as_view()),
     
-	path('projects/', ProjectList.as_view()),
+        path('projects/', ProjectList.as_view()),
+
+        path('api/password-reset/', PasswordResetView.as_view(), name='password-reset'),
+        path('reset-confirm/<uidb64>/<token>/', PasswordResetConfirmView.as_view(), name='password-reset-confirm'),
 
 	path('api/register/', UserRegistrationAPIView.as_view(), name='register'),
 	path('api/token/', MyTokenObtainPairView.as_view(), name='token_obtain_pair'),

--- a/base/views.py
+++ b/base/views.py
@@ -5,14 +5,35 @@ from rest_framework.permissions import AllowAny
 from rest_framework_simplejwt.views import TokenObtainPairView
 from rest_framework.permissions import IsAdminUser
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
-from rest_framework.generics import ListAPIView, CreateAPIView, ListCreateAPIView, RetrieveUpdateAPIView
+from rest_framework.generics import (
+    ListAPIView,
+    CreateAPIView,
+    ListCreateAPIView,
+    RetrieveUpdateAPIView,
+)
 from rest_framework.exceptions import ValidationError
 from rest_framework_simplejwt.tokens import AccessToken
 from rest_framework.permissions import IsAuthenticated
+from django.contrib.auth.models import User
+from django.contrib.auth.tokens import default_token_generator
+from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from django.utils.encoding import force_bytes, force_str
+from django.core.mail import send_mail
+from django.conf import settings
 
 from .models import Comment, TechnicalSkillCategory, TechnicalSkill, WorkExperience, Study, Project
-from .serializers import TechnicalSkillCategorySerializer, TechnicalSkillSerializer, WorkExperienceSerializer, \
-    StudySerializer, CommentSerializer, ProjectSerializer, MyTokenObtainPairSerializer, UserRegistrationSerializer
+from .serializers import (
+    TechnicalSkillCategorySerializer,
+    TechnicalSkillSerializer,
+    WorkExperienceSerializer,
+    StudySerializer,
+    CommentSerializer,
+    ProjectSerializer,
+    MyTokenObtainPairSerializer,
+    UserRegistrationSerializer,
+    PasswordResetSerializer,
+    PasswordResetConfirmSerializer,
+)
 
 
 class UserRegistrationAPIView(APIView):
@@ -115,3 +136,52 @@ class ProjectList(ListAPIView):
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer
     permission_classes = [AllowAny]
+
+
+class PasswordResetView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        serializer = PasswordResetSerializer(data=request.data)
+        if serializer.is_valid():
+            email = serializer.validated_data["email"]
+            try:
+                user = User.objects.get(email=email)
+            except User.DoesNotExist:
+                # Do not reveal whether the email exists
+                return Response({"detail": "If the email exists, a reset link has been sent."}, status=status.HTTP_200_OK)
+
+            token = default_token_generator.make_token(user)
+            uid = urlsafe_base64_encode(force_bytes(user.pk))
+            reset_link = request.build_absolute_uri(f"/base/reset-confirm/{uid}/{token}/")
+            send_mail(
+                "Password reset",
+                f"Use the link below to reset your password:\n{reset_link}",
+                settings.DEFAULT_FROM_EMAIL,
+                [email],
+            )
+            return Response({"detail": "If the email exists, a reset link has been sent."}, status=status.HTTP_200_OK)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class PasswordResetConfirmView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request, uidb64, token):
+        serializer = PasswordResetConfirmSerializer(data=request.data)
+        if serializer.is_valid():
+            try:
+                uid = force_str(urlsafe_base64_decode(uidb64))
+                user = User.objects.get(pk=uid)
+            except (TypeError, ValueError, OverflowError, User.DoesNotExist):
+                return Response({"detail": "Invalid link."}, status=status.HTTP_400_BAD_REQUEST)
+
+            if not default_token_generator.check_token(user, token):
+                return Response({"detail": "Invalid or expired token."}, status=status.HTTP_400_BAD_REQUEST)
+
+            user.set_password(serializer.validated_data["new_password"])
+            user.save()
+            return Response({"detail": "Password has been reset."}, status=status.HTTP_200_OK)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary
- add console email backend
- add password reset serializers
- implement API views for requesting reset links and confirming password resets
- register URLs for new endpoints

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684a926fa24c8331923662ede93e3cde