### PR TITLE
Implement password reset functionality

### DIFF
--- a/back_port/settings.py
+++ b/back_port/settings.py
@@ -142,3 +142,7 @@ ROOT_URLCONF = 'back_port.urls'
 # WSGI Configuration
 # --------------------------------------
 WSGI_APPLICATION = 'back_port.wsgi.application'
+
+# Email settings
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+DEFAULT_FROM_EMAIL = 'webmaster@localhost'

--- a/base/serializers.py
+++ b/base/serializers.py
@@ -148,3 +148,12 @@ class ProjectSerializer(serializers.ModelSerializer):
     class Meta:
         model = Project
         fields = ['id', 'title', 'github_link', 'description', 'skills', 'images']
+
+# Password reset
+class PasswordResetSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+
+class PasswordResetConfirmSerializer(serializers.Serializer):
+    uid = serializers.CharField()
+    token = serializers.CharField()
+    new_password = serializers.CharField(write_only=True)

--- a/base/urls.py
+++ b/base/urls.py
@@ -1,5 +1,20 @@
 from django.urls import path
-from .views import CommentList, TechnicalSkillCategoryList, WorkExperienceList, ValidateTokenView, TechnicalSkillCategoryCreate, TechnicalSkillCreate, TechnicalSkillUpdate, TechnicalSkillCategoryUpdate, StudyList, ProjectList, MyTokenObtainPairView, UserRegistrationAPIView
+from .views import (
+    CommentList,
+    TechnicalSkillCategoryList,
+    WorkExperienceList,
+    ValidateTokenView,
+    TechnicalSkillCategoryCreate,
+    TechnicalSkillCreate,
+    TechnicalSkillUpdate,
+    TechnicalSkillCategoryUpdate,
+    StudyList,
+    ProjectList,
+    MyTokenObtainPairView,
+    UserRegistrationAPIView,
+    PasswordResetView,
+    PasswordResetConfirmView,
+)
 from rest_framework_simplejwt.views import TokenRefreshView
 
 
@@ -16,7 +31,10 @@ urlpatterns = [
 
 	path('comments/', CommentList.as_view()),
     
-	path('projects/', ProjectList.as_view()),
+        path('projects/', ProjectList.as_view()),
+
+        path('api/password-reset/', PasswordResetView.as_view(), name='password-reset'),
+        path('reset-confirm/<uidb64>/<token>/', PasswordResetConfirmView.as_view(), name='password-reset-confirm'),
 
 	path('api/register/', UserRegistrationAPIView.as_view(), name='register'),
 	path('api/token/', MyTokenObtainPairView.as_view(), name='token_obtain_pair'),


### PR DESCRIPTION
## Summary
- add console email backend
- add password reset serializers
- implement API views for requesting reset links and confirming password resets
- register URLs for new endpoints
- use `get_user_model` and `reverse` when processing reset requests

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: Set the DB_NAME environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_684a926fa24c8331923662ede93e3cde